### PR TITLE
Fix lagging network since update to lws 3.x

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -35,8 +35,8 @@ char *__process_states[] = {"created", "starting", "running", "stopping", "stopp
 
 // websocket protocols
 static const struct lws_protocols protocols[] = {
-        {"http-only", callback_http, sizeof(struct pss_http),   128, 0, NULL, 0},
-        {"tty",       callback_tty,  sizeof(struct tty_client), 128, 0, NULL, 0},
+        {"http-only", callback_http, sizeof(struct pss_http),   8192, 0, NULL, 0},
+        {"tty",       callback_tty,  sizeof(struct tty_client), 8192, 0, NULL, 0},
         {NULL, NULL, 0, 0, 0, NULL, 0}
 };
 
@@ -929,8 +929,9 @@ int main(int argc, char **argv) {
 
     // libwebsockets main loop
     while(!force_exit) {
-        lws_service(context, 10);
+        lws_service(context, -1);
         process_watch();
+        usleep(5000);
     }
 
     printf("[+] exiting\n");


### PR DESCRIPTION
libwebsockets since 3.x have changed their API about lws_service timeout which introduce lags for our usage. To handle that correctly, lot of changes should be done, but this fix is a workaround to get quick response working again.